### PR TITLE
Updated Podfile for compatibility with cocoapods 1.0+

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,16 @@
 # CastHelloVideo-ios
 platform :ios, '6.0'
-pod 'google-cast-sdk'
-link_with 'HelloVideoGoogleCastObjectiveC', 'HelloVideoGoogleCastSwift'
 
+target 'HelloVideoGoogleCastObjectiveC' do
+  use_frameworks!
+
+  pod 'google-cast-sdk'
+
+end
+
+target 'HelloVideoGoogleCastSwift' do
+  use_frameworks!
+
+  pod 'google-cast-sdk'
+
+end


### PR DESCRIPTION
link_with has been depreciated and no longer works, so to run the examples we need to update the podfile.